### PR TITLE
Rename Arcana as StorageProvider during export in index.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ import { Arcana } from '@arcana/storage/dist/standalone/storage.umd';
 ```js
 // address: Smart contract address of app
 // private key: Secp256K private key
-const arcanaInstance = new arcana.storage.Arcana({ appId, privateKey, email });
+const arcanaInstance = new arcana.storage.StorageProvider({ appId, privateKey, email });
 ```
 
 ### Uploader

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { Arcana as ArcanaT } from './typechain';
 import * as Sentry from '@sentry/browser';
 import { Integrations } from '@sentry/tracing';
 
-export class Arcana {
+export class StorageProvider {
   private wallet: Wallet;
   private convergence: string;
   private email: string;

--- a/test/test.js
+++ b/test/test.js
@@ -61,7 +61,7 @@ describe('Upload File', () => {
     file = MockFile('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.txt', 2 ** 20, 'image/txt');
     file = new File([file], file.name, { type: file.type });
     const wallet = await arcana.storage.utils.getRandomWallet();
-    arcanaInstance = new arcana.storage.Arcana({
+    arcanaInstance = new arcana.storage.StorageProvider({
       appId,
       privateKey: wallet.privateKey,
       email: makeEmail(),
@@ -103,7 +103,7 @@ describe('Upload File', () => {
   it('Fail download tranaction', async () => {
     receiverWallet = await arcana.storage.utils.getRandomWallet();
     console.log('Receiver wallet address', receiverWallet.address);
-    sharedInstance = new arcana.storage.Arcana({
+    sharedInstance = new arcana.storage.StorageProvider({
       appId,
       privateKey: receiverWallet,
       email: makeEmail(),


### PR DESCRIPTION
The auth SDK exports an AuthProvider, hence storage SDK exports StorageProvider