### PR TITLE
Fix module resolution errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "types"
   ],
   "scripts": {
-    "build": "npm run build:ts && npm run build:web",
-    "build:web": "rimraf dist/ && webpack",
-    "build:ts": "rimraf types/ && tsc --project tsconfig.json",
+    "build": "rimraf dist types && npm run build:ts && npm run build:web",
+    "build:web": "webpack",
+    "build:ts": "tsc --project tsconfig.json",
     "prettier": "prettier --write \"src/**/*.ts\" \"test/**/*.js\"  ",
     "lint": "tslint -p tsconfig.json",
     "prepare": "npm run build",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,3 @@
-(window as any).global = window;
-// @ts-ignore
-window.Buffer = window.Buffer || require('buffer').Buffer;
-
 import { Uploader } from './Uploader';
 import { Downloader } from './Downloader';
 import { Access } from './Access';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "module": "umd",
+    "module": "commonjs",
     "outDir": "dist",
     "declaration": true,
     "declarationDir": "types",


### PR DESCRIPTION
Diagnosis: Webpack can't somehow handle UMD modules, so when TypeScript was configured to generate UMD modules,
Webpack could no longer bundle them correctly, even if it emitted no errors.

Ticket URL: https://team-1624093970686.atlassian.net/browse/AR-1320?atlOrigin=eyJpIjoiMmY4YTEyZGM3YWRiNDJmNWI5MDE5OTkxMWZlNGI2MjIiLCJwIjoiaiJ9