### PR TITLE
metadata external url change

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -142,7 +142,7 @@ export class StorageProvider {
         break;
     }
 
-    let external_url = `https://nftviewer${subDomain}.arcana.network/asset/${did}`;
+    let external_url = `https://nft-viewer${subDomain}.arcana.network/asset/${did}`;
 
     let res2 = await api.post('/api/v1/metadata', {
       title,


### PR DESCRIPTION
# Pull Request Template

Resolves [AR-3483](https://team-1624093970686.atlassian.net/browse/AR-3483).

## Changes

Changed old NFT metadata external url of which was _nftviewer.<env>.arcana..._ 

**to** _nft-viewer.<env>.arcana_.... 

