### PR TITLE
New FileAPI

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,7 +52,7 @@ Downloader.download(did);
 ### Get Access
 
 ```js
-const Access = arcanaInstance.getAccess();
+const FileAPI = arcanaInstance.getAccess();
 ```
 
 #### Share a File
@@ -61,7 +61,7 @@ const Access = arcanaInstance.getAccess();
 // did: DID of file to be shared, can be a hexadecimal string or an array of such strings
 // address: recipients address, similar type as "did"
 // validity (optional): For how long will be the user able to download the file, e.g. [400] would mean 400 seconds.
-Access.share(did, address);
+FileAPI.share(did, address);
 ```
 
 #### Revoke File Sharing
@@ -69,25 +69,26 @@ Access.share(did, address);
 ```js
 // did: DID of file from which access is removed
 // address: Address of the user who's access is getting revoked
-Access.revoke(did, address);
+FileAPI.revoke(did, address);
 ```
 
 #### Transfer File Ownership
 
 ```js
 // address: new owner's address
-Access.changeFileOwner(did, address);
+FileAPI.changeFileOwner(did, address);
 ```
 
 #### Delete a File
 
 ```js
-Access.deleteFile(did);
+FileAPI.deleteFile(did);
 ```
 
 #### Get Listed of users who are having access to the file
+
 ```js
-Access.getSharedUsers(did)
+FileAPI.getSharedUsers(did)
 ```
 
 ### Storage Usage Metrics
@@ -96,13 +97,13 @@ Access.getSharedUsers(did)
 
 ```js
 //Get consumed and total storage of the current user
-let [consumed, total] = await Access.getUploadLimit();
+let [consumed, total] = await FileAPI.getUploadLimit();
 ```
 #### Get Download Limit
 
 ```js
 //Get consumed and total bandwidth of the current user
-let [consumed, total] = await Access.getDownloadLimit();
+let [consumed, total] = await FileAPI.getDownloadLimit();
 ```
 
 #### List Shared Files

--- a/integration-tests/test.js
+++ b/integration-tests/test.js
@@ -94,7 +94,7 @@ describe('Upload File', () => {
   //   await downloadArcana.downloadDID('0x03dcef07ceeb3c4bbb554a568b3a33d58df3bb7e9c527f9e1204a124ea5d1ee0');
   // });
 
-  
+
   it('My files', async () => {
     let files = await arcanaInstance.sharedFiles();
     console.log({files})
@@ -125,7 +125,7 @@ describe('Upload File', () => {
     chai.expect(tx).not.null;
   });
 
-  
+
   // it('Change File Owner', async () => {
   //   let newOwner = '0x04efC2A7E86cBaD7e5e65fc60eedfa92A413890e';
   //   let tx = await access.changeFileOwner(did, newOwner);
@@ -191,10 +191,10 @@ describe('Upload File', () => {
   //   );
   //   console.log(metadata);
   // });
-  
+
 
   // it("Should link nft", async ()=> {
-  //   let 
+  //   let
   //     chainId = 80001,
   //       tokenId  = 3,
   //       nftContract = "0xE80FCAD702b72777f5036eF1a76086FD3f882E29"
@@ -255,7 +255,7 @@ describe('Upload File', () => {
   //   chai.expect(files[0]['size']).equal(file.size);
   // });
 
-  
+
 
   // it('Should download a file', async () => {
   //   let download = await arcanaInstance.getDownloader();
@@ -321,8 +321,8 @@ describe('Upload File', () => {
   // });
 
   // it('Get consumed and total upload limit', async () => {
-  //   const Access = await arcanaInstance.getAccess();
-  //   let [consumed, total] = await Access.getUploadLimit(did);
+  //   const FileAPI = await arcanaInstance.getAccess();
+  //   let [consumed, total] = await FileAPI.getUploadLimit(did);
   //   chai.expect(consumed).equal(file.size);
   // });
 
@@ -351,15 +351,15 @@ describe('Upload File', () => {
   // })
 
   // it('Get consumed and total download limit', async () => {
-  //   const Access = await sharedInstance.getAccess();
-  //   let [consumed, total] = await Access.getDownloadLimit(did);
+  //   const FileAPI = await sharedInstance.getAccess();
+  //   let [consumed, total] = await FileAPI.getDownloadLimit(did);
   //   chai.expect(consumed).equal(file.size);
   // });
 
   // it('Delete Account', async () => {
-  //   const Access = await sharedInstance.getAccess();
-  //   await Access.deleteAccount();
-  //   chai.expect(await Access.getAccountStatus()).equal(2);
+  //   const FileAPI = await sharedInstance.getAccess();
+  //   await FileAPI.deleteAccount();
+  //   chai.expect(await FileAPI.getAccountStatus()).equal(2);
   // });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Uploader } from './Uploader';
 import { Downloader } from './Downloader';
-import { Access } from './Access';
+import { FileAPI } from './fileAPI';
 import { Config, customError, getFile, getProvider, makeTx, parseHex } from './Utils';
 import axios, { AxiosInstance } from 'axios';
 import { init as SentryInit } from '@sentry/browser';
@@ -19,6 +19,7 @@ export class StorageProvider {
   private chainId: number;
   private debug: boolean;
   private initialisedPromise: Promise<void>;
+  public files: FileAPI;
 
   constructor(cfg: Config) {
     let config;
@@ -99,9 +100,8 @@ export class StorageProvider {
     return new Uploader(this.appId, this.appAddress, this.provider, this.api, this.debug);
   };
 
-  getAccess = async (): Promise<Access> => {
-    await this.login();
-    return new Access(this.appAddress, this.provider, this.api, this.debug);
+  getAccess = async (): Promise<FileAPI> => {
+    return this.files;
   };
 
   getDownloader = async (): Promise<Downloader> => {
@@ -239,58 +239,34 @@ export class StorageProvider {
         throw new Error('app_not_found');
       }
     }
+
+    this.files = new FileAPI(this.appAddress, this.provider, this.api, this.debug)
   };
 
-  numOfMyFiles = async () => {
-    await this.login();
-    return (await this.api('files/total/')).data;
+  // TODO: remove when breaking backward compatibility
+  numOfMyFiles = () => {
+    return this.files.numOfMyFiles()
   }
 
   numOfMyFilesPages = async (pageSize: number = 20) => {
-    const numOfPages = (await this.numOfMyFiles()) / pageSize;
-    return Math.ceil(numOfPages);
+    return this.files.numOfMyFilesPages(pageSize)
   }
 
   myFiles = async (pageNumber: number = 1, pageSize: number = 20) => {
-    await this.login();
-    if(pageNumber > await this.numOfMyFilesPages(pageSize)){
-      throw new Error("invalid_page_number");
-    }
-    const res = await this.api.get('list-files/',{
-      params: {
-        offset: (pageNumber - 1) * pageSize,
-        count: pageSize
-      }
-    })
-    let data = [];
-    if (res.data) data = res.data;
-    return data;
-  };
+    return this.files.myFiles(pageNumber, pageSize)
+  }
 
-  numOfSharedFiles = async () => {
-    await this.login();
-    return (await this.api('files/shared/total/')).data;
+  numOfSharedFiles = () => {
+    return this.files.numOfSharedFiles()
   }
 
   numOfSharedFilesPages = async (pageSize: number = 20) => {
-    return Math.ceil((await this.numOfSharedFiles()) / pageSize);
+    return this.files.numOfSharedFilesPages(pageSize)
   }
 
-  sharedFiles = async (pageNumber: number = 1, pageSize: number=20) => {
-    await this.login();
-    if(pageNumber > await this.numOfSharedFilesPages(pageSize)){
-      throw new Error("invalid_page_number");
-    }
-    const res = await this.api('shared-files/', {
-      params: {
-        offset: (pageNumber - 1) * pageSize,
-        count: pageSize
-      }
-    })
-    let data = [];
-    if (res.data) data = res.data;
-    return data;
-  };
+  sharedFiles = async (pageNumber: number = 1, pageSize: number = 20) => {
+    return this.files.sharedFiles(pageNumber, pageSize)
+  }
 
   linkNft = async (fileId:string, tokenId: number, nftContract:string, nftChainID: number) => {
     await this.login();
@@ -316,3 +292,4 @@ export class StorageProvider {
     return downloader.download(did)
   }
 }
+export { AccessTypeEnum } from './fileAPI'

--- a/usage.md
+++ b/usage.md
@@ -44,53 +44,43 @@ Downloader.onProgress = (bytesDownloaded, bytesTotal) => { console.log('Progress
 Downloader.download(did);
 ```
 
-## Get Access
-
-```typescript
-const Access = new storage.getAccess();
-
-// Share a File
-// did: DID of file to be shared
-// address: recipients address
-// validity (optional): For how long will be the user able to download the file, e.g. [400] would mean 400 seconds
-Access.share([did], [address]);
-```
+## Access Control
 
 ### Revoke File Sharing
 
-```typescript
+```javascript
 // did: DID of file from which access is removed
 // address: Address of the user who's access is getting revoked
-Access.revoke(did, address);
+storage.files.revoke(did, address);
 ```
 
 ### Change File Ownership
 
-```typescript
+```javascript
 // address: new owner's address
-Access.changeFileOwner(did, address);
+storage.files.changeFileOwner(did, address);
 ```
 
 ### Delete a File
 
-```typescript
-Access.deleteFile(did);
+```javascript
+storage.files.deleteFile(did);
 ```
 
 ## Storage Usage Metrics
 
 ### Get Upload Limit
 
-```typescript
+```javascript
 //Get consumed and total storage of the current user
-let [consumed, total] = await Access.getUploadLimit();
+let [consumed, total] = await storage.files.getUploadLimit();
 ```
 
 ### Get Download Limit
 
-```typescript
+```javascript
 //Get consumed and total bandwidth of the current user
-let [consumed, total] = await Access.getDownloadLimit();
+let [consumed, total] = await storage.files.getDownloadLimit();
 ```
 
 ### List of Files Shared
@@ -98,8 +88,7 @@ let [consumed, total] = await Access.getDownloadLimit();
 List files shared with the current user.
 
 ```javascript
-//Get files shared with the current user
-let files = await storage.sharedFiles();
+let files = await storage.files.list(AccessTypeEnum.SHARED_FILES);
 ```
 
 ### List of Files Uploaded
@@ -107,10 +96,16 @@ let files = await storage.sharedFiles();
 List files uploaded by the current user.
 
 ```javascript
-//List of files uploaded by the current user
-let files = await storage.myFiles();
+let files = await storage.files.list(AccessTypeEnum.MY_FILES);
 ```
 ---
+### Old Access API
+
+Anything you can do with `storage.files` can also be done with the `Access` object returned by `storage.getAccess`.
+
+```javascript
+const Access = await storage.getAccess();
+```
 
 ## Download File by DID
 


### PR DESCRIPTION
# Pull Request Template

Continues [AR-3563](https://team-1624093970686.atlassian.net/browse/AR-3563) to resolution.

## Blocking dependencies

None.

## Changes

Last portion of AR-3563, implements the `Storage.files` API as discussed [on Confluence](https://team-1624093970686.atlassian.net/wiki/x/NYDfD).

Not implementing the `.usage` API since it is already part of the `.files` API and is unnecessary.

## Checklist

- [x] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
