### PR TITLE
Fix download when onProgress isn't specified

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -277,8 +277,11 @@ export class StorageProvider {
 
   upload = async (fileRaw: any, onProgress: (bytesUploaded: number, bytesTotal: number) => void): Promise<string> => {
     const uploader = await this.getUploader();
-    uploader.onProgress = onProgress;
 
+    if (onProgress != null) {
+      uploader.onProgress = onProgress;
+    }
+    
     return new Promise((resolve, reject) => {
       uploader.onError = reject;
       uploader.upload(fileRaw).then(resolve).catch(reject);
@@ -287,7 +290,10 @@ export class StorageProvider {
 
   download = async (did: any, onProgress: (bytesDownloaded: number, bytesTotal: number) => void): Promise<void> => {
     const downloader = await this.getDownloader();
-    downloader.onProgress = onProgress;
+
+    if (onProgress != null) {
+      downloader.onProgress = onProgress;
+    }
 
     return downloader.download(did)
   }


### PR DESCRIPTION
# Pull Request Template

Resolves [AR-3813](https://team-1624093970686.atlassian.net/browse/AR-3813).

## Blocking dependencies

None.

## Changes

The `download ` method doesn't work when `onProgress` is _not_ specified, since `onProgress` would be undefined, and it'd be trying to call undefined. Fixes it for both `upload` and `download` but `upload` isn't affected.

## Checklist

- [x] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
