### PR TITLE
Show Storage SDK version number in the API Ref

### DIFF
--- a/typedochtml.json
+++ b/typedochtml.json
@@ -6,6 +6,7 @@
   "excludeProtected": true,
   "excludeInternal": true,
   "excludeExternals": true,
+  "includeVersion": true,
   "footerDate": true,
   "footerTime": true,
   "plugin": ["typedoc-plugin-extras", "typedoc-plugin-missing-exports"]


### PR DESCRIPTION
@SauravKanchan Adding this to bring it at par with the auth sdk ref guide title - we include version info there.

# Pull Request Template

Resolves or continues [AR-4882](https://team-1624093970686.atlassian.net/browse/AR-4869).

## Blocking dependencies
NA

## Changes

Show Storage SDK version in the API Ref Guide

## Checklist

- [ ] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [ ] The changes have been tested locally.
